### PR TITLE
don't bother stripping off the leading forward slash, instead it should ...

### DIFF
--- a/lib/stork/client/plugins/host_list.rb
+++ b/lib/stork/client/plugins/host_list.rb
@@ -3,7 +3,7 @@ module HostListPlugin
     banner "stork host list (options)"
 
     def run
-      data = fetch('/hosts')
+      data = fetch('hosts')
       data['hosts'].sort.each do |host|
         puts host
       end

--- a/lib/stork/client/plugins/host_show.rb
+++ b/lib/stork/client/plugins/host_show.rb
@@ -5,7 +5,7 @@ module HostShowPlugin
     def run
       host = args.shift
       raise SyntaxError, "A host must be supplied" if host.nil?
-      data = fetch("/host/#{host}")
+      data = fetch("host/#{host}")
       show('name', data)
       show('distro', data)
       show('template', data)


### PR DESCRIPTION
...just be a convention to never to use the leading slash when using fetch.  Fixes #10.
