### PR TITLE
use webrick as the server and daemonize only if explicitly directed to

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       sinatra
       sqlite3
       thin
+      webrick
 
 GEM
   remote: https://rubygems.org/
@@ -59,6 +60,7 @@ GEM
     thor (0.19.1)
     tilt (1.4.1)
     tins (1.1.0)
+    webrick (1.3.1)
     yard (0.8.7.4)
 
 PLATFORMS

--- a/bin/storkctl
+++ b/bin/storkctl
@@ -19,14 +19,18 @@ class StorkCtlApp
   def initialize
     @options = OpenStruct.new
     @options.config = ENV['STORK_CONFIG'] || "/etc/stork/config.rb"
+    @options.daemonize = false
     @options.command = :start
   end
 
   def parse
     opts = OptionParser.new do |o|
       o.banner = "Usage: storkctl start|stop|restart [options]"
-      o.on("-c", "--config FILE", "Read configuration from the specified file") do |config|
+      o.on("-c", "--config FILE", "Read configuration from the specified file.") do |config|
         @options.config = config
+      end
+      o.on("-d", "--daemonize", "Daemonize stork.") do
+        @options.daemonize = true
       end
     end
 
@@ -46,11 +50,11 @@ class StorkCtlApp
   def run
     case @options.command
     when :start
-      Stork::Server::Control.start(@configuration)
+      Stork::Server::Control.new(@configuration, @options).start
     when :stop
-      Stork::Server::Control.stop(@configuration)
+      Stork::Server::Control.new(@configuration, @options).stop
     when :restart
-      Stork::Server::Control.restart(@configuration)
+      Stork::Server::Control.new(@configuration, @options).restart
     end
   end
 end

--- a/lib/stork/server/control.rb
+++ b/lib/stork/server/control.rb
@@ -1,37 +1,92 @@
 require 'sinatra'
 require 'json'
 require 'rack'
-require 'thin'
+require 'webrick'
 
 module Stork
   module Server
     class Control
-      def self.start(configuration)
-        puts "Starting stork server on port #{configuration.port}."
-        app = Stork::Server::Application
-        app.set :config, configuration
-        app.set :collection, Stork::Builder.load(configuration).collection
+      def initialize(configuration, options)
+        @configuration = configuration
+        @app = Stork::Server::Application
+        # @thin = Thin::Server.new(@configuration.bind, @configuration.port, app)
+        @daemonize = options.daemonize
+      end
 
-        @thin = Thin::Server.new(configuration.bind, configuration.port, app)
-        @thin.tag = "Stork #{VERSION}"
-        unless ENV['RACK_ENV'] == 'test'
-          @thin.pid_file = configuration.pid_file
-          @thin.log_file = configuration.log_file
-          @thin.daemonize
-        else
-          puts '!!! Running in test mode'
+      # Basic start management borrowed from chef-zero.  Could there be a
+      # way to utilize any light http servers (thin, puma, unicorn)?
+      def start
+        @app.set :config, @configuration
+        @app.set :collection, Stork::Builder.load(@configuration).collection
+
+        unless is_daemon?
+          puts <<-EOH.gsub(/^ {12}/, '')
+            >> Starting Stork Server (#{Stork::VERSION})...
+            >> WEBrick (#{WEBrick::VERSION}) with Rack (#{Rack.release}) is listening on #{@configuration.bind}:#{@configuration.port}
+            >> Press CTRL+C to stop
+
+          EOH
         end
-        @thin.start
+
+        thread = start_background
+        %w[INT TERM].each { |signal| trap_signal(signal) }
+        thread.join
       end
 
-      def self.stop(configuration)
-        puts 'Stoping the stork server.'
-        Thin::Server.kill(configuration.pid_file)
+      def trap_signal(signal)
+        Signal.trap(signal) do
+          puts "\n>> Stopping Stork..."
+          @server.shutdown
+        end
       end
 
-      def self.restart(configuration)
-        stop(configuration)
-        start(configuration)
+      def start_background
+        @server = WEBrick::HTTPServer.new(
+          :BindAddress => @configuration.bind,
+          :Port =>        @configuration.port,
+          :AccessLog =>   [],
+          :Logger =>      WEBrick::Log.new(StringIO.new, 7),
+          :StartCallback => proc { @running = true }
+        )
+        @server.mount('/', Rack::Handler::WEBrick, @app)
+
+        @thread = Thread.new do
+          begin
+            Thread.current.abort_on_exception = true
+            @server.start
+          ensure
+            @running = false
+          end
+        end
+        # Do not return until the web server is genuinely started.
+        while !@running && @thread.alive?
+          sleep(0.01)
+        end
+        @thread
+      end
+
+      def is_daemon?
+        @daemonize
+      end
+
+      def stop(wait = 5)
+        if @running
+          @server.shutdown
+          @thread.join(wait)
+        end
+      rescue Timeout::Error
+        if @thread
+          # ChefZero::Log.error("Chef Zero did not stop within #{wait} seconds! Killing...")
+          @thread.kill
+        end
+      ensure
+        @server = nil
+        @thread = nil
+      end
+
+      def restart
+        stop
+        start
       end
     end
   end

--- a/stork.gemspec
+++ b/stork.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sinatra"
-  spec.add_runtime_dependency "thin"
+  spec.add_runtime_dependency "webrick"
   spec.add_runtime_dependency "sqlite3"
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "highline"


### PR DESCRIPTION
Fixes #15.  Added daemonize option and ensure that stork only daemonizes if that option is given.  Thin was removed and replaced with webrick because the headers it prints out at the start of the thin server cannot be turned off or customized without monkey patching thin.  It would be good to see if we can make the http server choice flexible and work with any of the rack compatible servers.
