### PR TITLE
add a public drop folder for misc files

### DIFF
--- a/lib/stork/configuration.rb
+++ b/lib/stork/configuration.rb
@@ -28,6 +28,7 @@ module Stork
     default(:templates_path) { relative_to_bundle_path('templates') }
     default(:chefs_path) { relative_to_bundle_path('chefs') }
     default(:distros_path) { relative_to_bundle_path('distros') }
+    default(:public_path) { relative_to_bundle_path('public') }
 
     default(:client_name) { 'root' }
     default(:client_key) { '~/.stork/root.pem' }

--- a/lib/stork/server/application.rb
+++ b/lib/stork/server/application.rb
@@ -77,6 +77,10 @@ module Stork
         end
       end
 
+      get '/public/:filename' do |file|
+        send_file public_path(file)
+      end
+
       not_found do
         json_halt_not_found
       end
@@ -113,6 +117,10 @@ module Stork
 
         def pxe(host)
           Stork::PXE.new(host, host.stork, Configuration.port)
+        end
+
+        def public_path(filename)
+          File.join(Configuration.public_path, filename)
         end
 
         def loginfo(msg)

--- a/specs/scripts/kssetup.sh
+++ b/specs/scripts/kssetup.sh
@@ -8,12 +8,12 @@ if [ "$TRAVIS" = "true" ] ; then
   cd pykickstart
   sudo python setup.py install
 else
-  pip install virtualenv
+  # pip install virtualenv
   echo "Creating virtual environment: ksvalidator"
   virtualenv ksvalidator
   cd ksvalidator
   echo "Activating!!!"
-  source bin/activate
+  . ./bin/activate
   echo "Installing packages"
   pip install pycurl
   pip install urlgrabber

--- a/specs/server_spec.rb
+++ b/specs/server_spec.rb
@@ -61,6 +61,11 @@ describe "Stork::Server::Application" do
     last_response.body.must_equal "{ \"status\":\"404\", \"message\": \"Not found\" }"
   end
 
+  it "should send a public file" do
+    get '/public/file.txt'
+    last_response.status.must_equal 200
+  end
+
   it "should notify of an install request" do
     get '/host/server.example.org/install'
     last_response.body.must_equal "{ \"status\":\"200\", \"message\": \"OK\" }"

--- a/specs/stork/bundles/public/file.txt
+++ b/specs/stork/bundles/public/file.txt
@@ -1,0 +1,5 @@
+# file.txt
+
+This is a regularly scheduled test of the emergency broadcast system.
+
+This is a test.  This is only a test.


### PR DESCRIPTION
Added a public folder that is exposed at http://<hostname>:<port>/public for downloading miscellanious files during the provisioning process.  Defaults to the <bundles_path>/public folder, but can be set in the configuration via the public_path option
