### PR TITLE
ip validation working.  not adding in the range include validation ye…

### DIFF
--- a/lib/stork/resource/base.rb
+++ b/lib/stork/resource/base.rb
@@ -1,3 +1,5 @@
+require "ipaddr"
+
 module Stork
   module Resource
     class Base
@@ -22,6 +24,29 @@ module Stork
 
       def require_value(attr)
         fail SyntaxError, "#{attr} is required" if send(attr).nil?
+      end
+
+      def require_valid_ips(attr)
+        values = send(attr)
+        values.each do |value|
+          fail SyntaxError, "#{value} is not a valid address" unless is_valid_ip?(value)
+        end
+      end
+
+      def require_valid_ip(attr)
+        value = send(attr)
+        if value
+          fail SyntaxError, "#{value} is not a valid address" unless is_valid_ip?(value)
+        end
+      end
+
+      def is_valid_ip?(ipaddr)
+        begin
+          IPAddr.new ipaddr
+          true
+        rescue IPAddr::InvalidAddressError
+          false
+        end
       end
 
       def self.build(name = nil, options = {}, &block)

--- a/lib/stork/resource/interface.rb
+++ b/lib/stork/resource/interface.rb
@@ -25,7 +25,7 @@ module Stork
       end
 
       def validate!
-
+        require_valid_ip :ip
       end
 
       def netmask

--- a/lib/stork/resource/network.rb
+++ b/lib/stork/resource/network.rb
@@ -1,3 +1,5 @@
+require "ipaddr"
+
 module Stork
   module Resource
     class Network < Base
@@ -13,7 +15,17 @@ module Stork
         @search_paths = Array.new
       end
 
+      def validate!
+        require_valid_ips :nameservers
+        require_valid_ip :gateway
+        require_valid_ip :netmask
+      end
+
       class NetworkDelegator < Stork::Resource::Delegator
+        def network(network)
+          delegated.network = network
+        end
+
         def netmask(netmask)
           delegated.netmask = netmask
         end

--- a/specs/resource_host_spec.rb
+++ b/specs/resource_host_spec.rb
@@ -118,19 +118,19 @@ describe "Stork::Resource::Host" do
       },
       'interfaces' => [
         { 
-          'ip' => '99.99.1.8',
+          'ip' => '192.168.0.15',
           'bootproto' => :static,
           'netmask' => '255.255.255.0',
-          'gateway' => nil,
-          'nameservers' => [],
-          'search_paths' => []
+          'gateway' => '192.168.0.1',
+          'nameservers' => ["192.168.0.2", "192.168.0.3"],
+          'search_paths' => ['example.org']
         },
         { 
           'ip' => '192.168.1.10',
           'bootproto' => :static,
           'netmask' => '255.255.255.0',
-          'gateway' => '192.168.1.1',
-          'nameservers' => ['192.168.1.253', '192.168.1.252'],
+          'gateway' => nil,
+          'nameservers' => [],
           'search_paths' => []
         }
       ],

--- a/specs/resource_interface_spec.rb
+++ b/specs/resource_interface_spec.rb
@@ -79,6 +79,27 @@ describe "Stork::Resource::Interface" do
     }.must_raise(SyntaxError)
   end
 
+  it "should error on invalid ip addresses" do
+    collection = Stork::Collections.new
+    proc {
+      Stork::Resource::Interface.build "eth0", collection: collection do
+        ip '1000.1000.1.1'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Interface.build "eth0", collection: collection do
+        ip 'hey.there.buddy'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Interface.build "eth0", collection: collection do
+        ip '1.1.1'
+      end
+    }.must_raise(SyntaxError)
+  end
+
   it "should have dhcp as the default for bootproto" do
     Stork::Resource::Interface.new('eth0').bootproto.must_equal :dhcp
   end

--- a/specs/resource_network_spec.rb
+++ b/specs/resource_network_spec.rb
@@ -29,6 +29,62 @@ describe "Stork::Resource::Network" do
     Stork::Resource::Network.new("local").must_respond_to :search_paths=
   end
 
+  it "must error if the netmask given is invalid" do
+    proc {
+      Stork::Resource::Network.build "test" do
+        netmask '2555555.255.255.0'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Network.build "test" do
+        netmask '255.255.255.foo'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Network.build "test" do
+        netmask 'howdy.there.pilgrim'
+      end
+    }.must_raise(SyntaxError)
+  end
+
+  it "must error if the gateway is invalid" do
+    proc {
+      Stork::Resource::Network.build "test" do
+        gateway '10.1.1.1111'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Network.build "test" do
+        gateway '10.1.1.blah'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Network.build "test" do
+        gateway 'wow, this is a really cool gateway'
+      end
+    }.must_raise(SyntaxError)
+  end
+
+  it "must error if the nameserver are invalid" do
+    proc {
+      Stork::Resource::Network.build "test" do
+        nameserver 'superfly'
+        nameserver '8.8.8.8'
+      end
+    }.must_raise(SyntaxError)
+
+    proc {
+      Stork::Resource::Network.build "test" do
+        nameserver '8.8.8.8'
+        nameserver 'superfly'
+      end
+    }.must_raise(SyntaxError)
+  end
+
   it "should build" do
     net = Stork::Resource::Network.build("local") do
       netmask "255.255.255.0"

--- a/specs/stork/bundles/hosts/example.org.rb
+++ b/specs/stork/bundles/hosts/example.org.rb
@@ -10,17 +10,14 @@ host "server.example.org" do
 
   interface "eth0" do
     bootproto :static
-    ip        "99.99.1.8"
-    # network   "org"
+    ip        "192.168.0.15"
+    network   "internal-one"
   end
 
   interface "eth1" do
     bootproto :static
     ip        "192.168.1.10"
-    netmask   "255.255.255.0"
-    gateway   "192.168.1.1"
-    nameserver "192.168.1.253"
-    nameserver "192.168.1.252"
+    network   "internal-two"
   end
 
   pre_snippet    "setup"
@@ -52,8 +49,8 @@ hosts.each do |octet, mac|
 
     interface "eth0" do
       bootproto :static
-      ip        "192.168.10.#{octet}"
-      network   "org"
+      ip        "192.168.0.#{octet}"
+      network   "internal-one"
     end
   end
 end

--- a/specs/stork/bundles/networks/internal-one.rb
+++ b/specs/stork/bundles/networks/internal-one.rb
@@ -1,0 +1,7 @@
+network "internal-one" do
+  netmask "255.255.255.0"
+  gateway "192.168.0.1"
+  nameserver "192.168.0.2"
+  nameserver "192.168.0.3"
+  search_path "example.org"
+end

--- a/specs/stork/bundles/networks/internal-two.rb
+++ b/specs/stork/bundles/networks/internal-two.rb
@@ -1,0 +1,3 @@
+network "internal-two" do
+  netmask "255.255.255.0"
+end

--- a/specs/stork/bundles/networks/local.rb
+++ b/specs/stork/bundles/networks/local.rb
@@ -1,6 +1,0 @@
-network "local" do
-  netmask "255.255.255.0"
-  gateway "192.168.1.1"
-  nameserver "192.168.1.253"
-  nameserver "192.168.1.252"
-end

--- a/specs/stork/bundles/networks/org.rb
+++ b/specs/stork/bundles/networks/org.rb
@@ -1,7 +1,0 @@
-network "org" do
-  netmask "255.255.255.0"
-  gateway "99.99.1.1"
-  nameserver "99.99.1.253"
-  nameserver "99.99.1.252"
-  search_path "example.org"
-end


### PR DESCRIPTION
…t as when the network is defined inline with the interface, it does not actually pick up the validation trigger from the build method and there are cases that a gateway (which is the only thing that I can use with the netmask to figure out the full range) will not be defined.  It would be nice to have that in there, but unless I rename the network object to subnet (or something like that) to let me use the common but deprecated network attribute that is found in both rhel and debian based configs, it will not be possible.

Resolves #2 

Thought of several situations where you would not want the gateway set (duh, stupid idea in the first place) so the second part of the issue - namely the autoconfiguration of the gateway address -  will not be included in this.